### PR TITLE
Bug fix: previous code generates empty string when litStr.size % chunkWidth == 0

### DIFF
--- a/src/main/scala/Emitter.scala
+++ b/src/main/scala/Emitter.scala
@@ -109,8 +109,8 @@ object Emitter {
   }
 
   def chunkLitString(litStr: String, chunkWidth:Int = 16): Seq[String] = {
-    if (litStr.size < chunkWidth) Seq(litStr)
-    else chunkLitString(litStr.dropRight(chunkWidth)) ++ Seq(litStr.takeRight(chunkWidth))
+    if (litStr.length % chunkWidth == 0) litStr.grouped(chunkWidth).toSeq
+    else Seq(litStr.take(litStr.length % chunkWidth)) ++ chunkLitString(litStr.drop(litStr.length % chunkWidth), chunkWidth)
   }
 
   // NOTE: assuming no large UIntLiteral is negative


### PR DESCRIPTION
Previous code returns extra empty string when litStr.size % chunkWidth == 0

Example: 

` 
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 18.0.2).
Type in expressions for evaluation. Or try :help.
// Code before this PR
scala> def chunkLitString(litStr: String, chunkWidth:Int = 16): Seq[String] = {
     |     if (litStr.size < chunkWidth) Seq(litStr)
     |     else chunkLitString(litStr.dropRight(chunkWidth)) ++ Seq(litStr.takeRight(chunkWidth))
     |   }
def chunkLitString(litStr: String, chunkWidth: Int): Seq[String]

scala> val testString = "0123456789ABCDEF"
val testString: String = 0123456789ABCDEF

scala> testString.size
val res0: Int = 16

scala> chunkLitString(testString, 16)
val res1: Seq[String] = List("", 0123456789ABCDEF)

scala> 
`

Finally emits C++ code like:

`UInt<128>(std::array<uint64_t,2>({0x,0xffffffffffffffff,0xffffffffffffffff}))`

The expected behavior should be same as the bug fix (no extra empty string):

`
// After this PR
scala> chunkLitString(testString, 16)
val res2: Seq[String] = List(0123456789ABCDEF)

scala> val testString = "0123456789ABCDEFF"
val testString: String = 0123456789ABCDEFF

scala> chunkLitString(testString, 16)
val res3: Seq[String] = List(0, 123456789ABCDEFF)
`

