### PR TITLE
Bump FIRRTL to 1.5.6; Update dependencies; Add passes to accomodate FIRRTL changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "0.8-SNAPSHOT"
 
 name := "essent"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.18"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
@@ -12,9 +12,9 @@ libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.1"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0" % "test"
 
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.6.9"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.6.12"
 
-libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.4.3"
+libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.5.6"
 
 
 // Assembly

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.6.2

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -304,7 +304,19 @@ class EssentEmitter(initialOpt: OptFlags, w: Writer, circuit: Circuit) extends L
 
 
 class EssentCompiler(opt: OptFlags) {
+
+  // VerilogMemDelays: compiling memory latencies to combinational-read memories with delay pipelines.
+  // This pass eliminates mems with read latency = 1 (introduced by CHIRRTL smem)
+  // and thus satisfy essent.pass.FactorMemReads (memHasRightParams)
+
+  // ConvertAsserts: Convert Verification IR (with op == Formal.Assert) into conventional print statement
+
   val readyForEssent: Seq[TransformDependency] =
+    Seq(
+      Dependency(firrtl.passes.memlib.VerilogMemDelays),
+      Dependency(essent.passes.RemoveFormalNCover),
+      Dependency(firrtl.transforms.formal.ConvertAsserts)
+    ) ++
     firrtl.stage.Forms.LowFormOptimized ++
     Seq(
 //      Dependency(essent.passes.LegacyInvalidNodesForConds),

--- a/src/main/scala/passes/RemoveFormalNCover.scala
+++ b/src/main/scala/passes/RemoveFormalNCover.scala
@@ -1,0 +1,42 @@
+package essent.passes
+
+import firrtl.Mappers._
+import firrtl._
+import firrtl.ir._
+import firrtl.passes._
+
+
+object RemoveFormalNCover extends Pass {
+  def desc = "Removes FIRRTL formal and coverage (Assume, Cover) as they are not supported by ESSENT"
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = firrtl.stage.Forms.LowFormOptimized
+  override def invalidates(a: Transform) = false
+
+  def removeUnsupported(s: Statement): Statement = s.map(removeUnsupported) match {
+    case Block(stmts) =>
+      val newStmts = stmts.filter{_ match {
+        case s: Verification => s.op match{
+          case Formal.Cover => false
+          case Formal.Assume => false
+          case _ => true
+        }
+        case _ => true
+      }}
+      newStmts.size match {
+        case 0 => EmptyStmt
+        case 1 => newStmts.head
+        case _ => Block(newStmts)
+      }
+    case sx => sx
+  }
+
+  private def onModule(m: DefModule): DefModule = {
+    m match {
+      case m: Module    => Module(m.info, m.name, m.ports, removeUnsupported(m.body))
+      case m: ExtModule => m
+    }
+  }
+  def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule), c.main)
+}

--- a/src/test/resources/ReplacedRsvdKey_correct.fir
+++ b/src/test/resources/ReplacedRsvdKey_correct.fir
@@ -1,3 +1,4 @@
+FIRRTL version 1.1.0
 circuit Testrsvd :
   module Break :
     input clk : Clock


### PR DESCRIPTION
Bump up FIRRTL to 1.5.6, the last SFC (Scala FIRRTL Compiler)  before MFC (MLIR FIRRTL Compiler).
Bump up json4s to satisfy FIRRTL 1.5.6 dependency.
Bump up Scala to satisfy FIRRTL 1.5.6 dependency.
Bump up sbt for more recent JDK support.
Add a new pass to remove formal and coverage IR nodes.
Invoke `firrtl.passes.memlib.VerilogMemDelays` to align the behavior of MemRead.
Invoke `firrtl.transforms.formal.ConvertAsserts` to transform assertions (Verification IR nodes with op == Formal.Assert) into combination of Print and Stop statements.
Fix expected result of `ReplaceRsvdKeywords` pass test.

Compilation passed under JDK11 and JDK 17, also on JDK21 if further bump sbt to 1.9.0
Correctly generates header file for RocketChip (Both Chisel 3.5.6 and 3.4.3), simulation (dhrystone) passed.