### PR TITLE
Compiler mini fix

### DIFF
--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -335,7 +335,7 @@ class EssentCompiler(opt: OptFlags) {
   def compileAndEmit(circuit: Circuit): Unit = {
     val topName = circuit.main
     if (opt.writeHarness) {
-      val harnessFilename = new File(opt.outputDir, s"$topName-harness.cc")
+      val harnessFilename = new File(opt.outputDir(), s"$topName-harness.cc")
       val harnessWriter = new FileWriter(harnessFilename)
       if (opt.withVCD) { HarnessGenerator.topFile(topName, harnessWriter," |  dut.genWaveHeader();") }
       else { HarnessGenerator.topFile(topName, harnessWriter, "")}
@@ -344,13 +344,13 @@ class EssentCompiler(opt: OptFlags) {
     val firrtlCompiler = new transforms.Compiler(readyForEssent)
     val resultState = firrtlCompiler.execute(CircuitState(circuit, Seq()))
     if (opt.dumpLoFirrtl) {
-      val debugFilename = new File(opt.outputDir, s"$topName.lo.fir")
+      val debugFilename = new File(opt.outputDir(), s"$topName.lo.fir")
       val debugWriter = new FileWriter(debugFilename)
       debugWriter.write(resultState.circuit.serialize)
       debugWriter.close()
     }
 
-    val outputDir = if (opt.outputDir.nonEmpty) opt.outputDir else System.getProperty("user.dir")
+    val outputDir = if (opt.outputDir().nonEmpty) opt.outputDir() else System.getProperty("user.dir")
     val dutFile = new File(outputDir, s"$topName.h")
 
     val dutWriter = new FileWriter(dutFile)

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -335,7 +335,7 @@ class EssentCompiler(opt: OptFlags) {
   def compileAndEmit(circuit: Circuit): Unit = {
     val topName = circuit.main
     if (opt.writeHarness) {
-      val harnessFilename = new File(opt.outputDir(), s"$topName-harness.cc")
+      val harnessFilename = new File(opt.outputDir, s"$topName-harness.cc")
       val harnessWriter = new FileWriter(harnessFilename)
       if (opt.withVCD) { HarnessGenerator.topFile(topName, harnessWriter," |  dut.genWaveHeader();") }
       else { HarnessGenerator.topFile(topName, harnessWriter, "")}
@@ -344,11 +344,16 @@ class EssentCompiler(opt: OptFlags) {
     val firrtlCompiler = new transforms.Compiler(readyForEssent)
     val resultState = firrtlCompiler.execute(CircuitState(circuit, Seq()))
     if (opt.dumpLoFirrtl) {
-      val debugWriter = new FileWriter(new File(opt.outputDir(), s"$topName.lo.fir"))
+      val debugFilename = new File(opt.outputDir, s"$topName.lo.fir")
+      val debugWriter = new FileWriter(debugFilename)
       debugWriter.write(resultState.circuit.serialize)
       debugWriter.close()
     }
-    val dutWriter = new FileWriter(new File(opt.outputDir(), s"$topName.h"))
+
+    val outputDir = if (opt.outputDir.nonEmpty) opt.outputDir else System.getProperty("user.dir")
+    val dutFile = new File(outputDir, s"$topName.h")
+
+    val dutWriter = new FileWriter(dutFile)
     val emitter = new EssentEmitter(opt, dutWriter,resultState.circuit)
     emitter.execute(resultState.circuit)
     dutWriter.close()


### PR DESCRIPTION
When running Essent on a file with no specified output/file path, it would default to the root directory due to the addition of a '/' in front of the output file name. This is potentially confusing behavior and could result in an error if permissions are not set appropriately. This fix changes it to use the file path of the user as the default output if no file path is given. 